### PR TITLE
CloudType 배포에 따른 ORM 및 DB 접속 URL 수정

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -22,14 +22,13 @@ class Configs(BaseSettings):
     UNIX_SOCKET: str = _getenv("UNIX_SOCKET")
 
     DATABASE_URI: str = (
-        "{db_engine}://{user}:{password}@{host}:{port}/{database}?{unix_socket}".format(
+        "{db_engine}://{user}:{password}@{host}:{port}/{database}".format(
             db_engine=DB_ENGINE,
             user=DB_USER,
             password=DB_PASSWORD,
             host=DB_HOST,
             port=DB_PORT,
             database=DATA_BASE,
-            unix_socket=UNIX_SOCKET,
         )
     )
 

--- a/app/model/records.py
+++ b/app/model/records.py
@@ -16,7 +16,7 @@ class StatusEnum(str, Enum):
 class EventTypes(BaseModel, table=True):
     """경조사 타입 테이블."""
 
-    __tablename__ = "eventtypes"
+    __tablename__ = "EventTypes"
 
     id: int = Field(default=None, primary_key=True)
     name: str = Field(sa_column=Column(String(48), nullable=False))
@@ -28,7 +28,7 @@ class EventTypes(BaseModel, table=True):
 class Relations(BaseModel, table=True):
     """관계 테이블"""
 
-    __tablename__ = "relations"
+    __tablename__ = "Relations"
 
     id: int = Field(default=None, primary_key=True)
     name: str = Field(sa_column=Column(String(48), nullable=False))
@@ -40,7 +40,7 @@ class Relations(BaseModel, table=True):
 class Records(BaseModel, table=True):
     """기록 테이블"""
 
-    __tablename__ = "records"
+    __tablename__ = "Records"
 
     id: int = Field(default=None, primary_key=True)
     event_type_id: int = Field(sa_column=Column(Integer, nullable=False))
@@ -66,4 +66,4 @@ class Records(BaseModel, table=True):
     memo: str = Field(sa_column=Column(String(225), nullable=True))
 
     class Config:
-        orm_mode = True
+        from_attributes = True

--- a/app/model/users.py
+++ b/app/model/users.py
@@ -24,7 +24,7 @@ class GenderEnum(str, Enum):
 class Users(BaseModel, table=True):
     """유저 테이블"""
 
-    __tablename__ = "users"
+    __tablename__ = "Users"
 
     id: int = Field(default=None, primary_key=True)
     email: str = Field(sa_column=Column(String(128), unique=True, nullable=False))

--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -22,10 +22,10 @@ class UserService:
 
     async def get_user_id(self, social_id: str):
         """social_id값으로 user_id값 반환하는 메소드."""
-        user_id = self.db.query(Users.id).filter(Users.social_id == social_id).scalar()
-        if user_id is None:
+        user = self.db.query(Users.id).filter(Users.social_id == social_id).first()
+        if user is None:
             raise NotFoundError(detail="해당 사용자를 찾을 수 없습니다.")
-        return user_id
+        return user.id
 
     async def signup_new_user(self, user_data):
         """신규유저 생성 메소드."""


### PR DESCRIPTION
## 📌 작업 내용
> CloudType 배포에 따른 ORM 및 DB 접속 URL 수정

## 📑 상세 작업 내용
### CloudType에선 MySQL 지원하지 않음

> 1.  RDBMS 중에 PostgreSQL 대신 MariaDB 사용한 이유 ? 
- 두 DB 모두 SQLAlchemy(Python ORM)와 호환되지만, PostgreSQL은 데이터 타입 및 제약 조건을 일부 수정해야 함.
- 또한, 기존 쿼리들이 정상적으로 동작하는지 점검이 필요함.
- 반면, MariaDB는 대소문자를 구분하므로 테이블명을 CamelCase로 변경하고, scalar() 메소드만 변경해주면 됨.

## 💬 기타 사항
DB 및 서버 배포 완료했습니다.
일단 두 개 모두 CloudType이라는 인프라 서비스를 통해 배포했는데, 과금내역 및 제공기능들을 1주 ~ 2주 정도 사용해보고, 
다시 한 번 점검해보아도 좋을 것 같습니다!

앞으로 API 문서는 여기 접속해서 보시면 될 것 같습니다! 
### 👉🏻 [API 문서](https://port-0-jugobatjang-backend-m8pss8pheb05dec2.sel4.cloudtype.app/docs)